### PR TITLE
Bug #10 - pandas version was upgraded | Dockerfile pinned to slim

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-bullseye
+FROM python:3.10-slim
 
 WORKDIR /code
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==2.2.5
 ncclient==0.6.9
-pandas==1.3.4
+pandas==2.3.2
 paramiko==2.7.2
 requests==2.25.1
 xmltodict==0.12.0


### PR DESCRIPTION
Pandas version pinned to 2.3.2
Dockerfile now using "slim"